### PR TITLE
feat: add static SOQL and SOSL support

### DIFF
--- a/apex-repository/recipes/classes/AccountServiceTest.cls
+++ b/apex-repository/recipes/classes/AccountServiceTest.cls
@@ -20,7 +20,7 @@ private class AccountServiceTest {
     // Arrange
     final InMemoryRepositoryService repository = new InMemoryRepositoryService();
     final AccountService sut = new AccountService(repository);
-    final Account account = new Account(Name = 'Test', Id = InMemoryRepositoryService.getFakeId(Account.getSObjectType()));
+    final Account account = new Account(Name = 'Test', Id = DatabaseTestUtils.getFakeId(Account.getSObjectType()));
     repository.mockDatabase.put(Account.getSObjectType(), new List<SObject>{ account });
 
     // Act
@@ -36,7 +36,7 @@ private class AccountServiceTest {
     // Arrange
     final InMemoryRepositoryService repository = new InMemoryRepositoryService();
     final AccountService sut = new AccountService(repository);
-    final Account account = new Account(Name = 'Test', Id = InMemoryRepositoryService.getFakeId(Account.getSObjectType()));
+    final Account account = new Account(Name = 'Test', Id = DatabaseTestUtils.getFakeId(Account.getSObjectType()));
     repository.mockDatabase.put(Account.getSObjectType(), new List<SObject>{ account });
 
     // Act
@@ -51,7 +51,7 @@ private class AccountServiceTest {
     // Arrange
     final InMemoryRepositoryService repository = new InMemoryRepositoryService();
     final AccountService sut = new AccountService(repository);
-    repository.mockDatabase.put(Account.getSObjectType(), new List<SObject>{ new Account(Name = 'Test', Id = InMemoryRepositoryService.getFakeId(Account.getSObjectType())) });
+    repository.mockDatabase.put(Account.getSObjectType(), new List<SObject>{ new Account(Name = 'Test', Id = DatabaseTestUtils.getFakeId(Account.getSObjectType())) });
 
     // Act
     final Account result = sut.getExistingAccount('Test')[0];

--- a/apex-repository/src/classes/DatabaseTestUtils.cls
+++ b/apex-repository/src/classes/DatabaseTestUtils.cls
@@ -1,0 +1,108 @@
+@isTest
+public class DatabaseTestUtils {
+  static Integer identifier = 1;
+  public static String getFakeId(Schema.SObjectType sot) {
+    String result = String.valueOf(identifier++);
+    return sot.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
+  }
+
+  public class DeleteResultBuilder {
+    private Boolean success;
+    private String id;
+    private List<Database.Error> errors;
+
+    public DeleteResultBuilder() {
+      this.success = true;
+      this.errors = new List<Database.Error>();
+    }
+
+    public DeleteResultBuilder withSuccess(Boolean success) {
+      this.success = success;
+      return this;
+    }
+
+    public DeleteResultBuilder withId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public DeleteResultBuilder withErrors(List<Database.Error> errors) {
+      this.errors = errors;
+      return this;
+    }
+
+    public Database.DeleteResult build() {
+      String jsonString = '{"success":' + String.valueOf(success) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
+      return (Database.DeleteResult) JSON.deserialize(jsonString, Database.DeleteResult.class);
+    }
+  }
+
+  public class UpsertResultBuilder {
+    private Boolean success;
+    private Boolean created;
+    private String id;
+    private List<Database.Error> errors;
+
+    public UpsertResultBuilder() {
+      this.success = true;
+      this.created = false;
+      this.errors = new List<Database.Error>();
+    }
+
+    public UpsertResultBuilder withSuccess(Boolean success) {
+      this.success = success;
+      return this;
+    }
+
+    public UpsertResultBuilder withCreated(Boolean created) {
+      this.created = created;
+      return this;
+    }
+
+    public UpsertResultBuilder withId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public UpsertResultBuilder withErrors(List<Database.Error> errors) {
+      this.errors = errors;
+      return this;
+    }
+
+    public Database.UpsertResult build() {
+      String jsonString = '{"success":' + String.valueOf(success) + ',"created":' + String.valueOf(created) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
+      return (Database.UpsertResult) JSON.deserialize(jsonString, Database.UpsertResult.class);
+    }
+  }
+
+  public class SaveResultBuilder {
+    private Boolean success;
+    private String id;
+    private List<Database.Error> errors;
+
+    public SaveResultBuilder() {
+      this.success = true;
+      this.errors = new List<Database.Error>();
+    }
+
+    public SaveResultBuilder withSuccess(Boolean success) {
+      this.success = success;
+      return this;
+    }
+
+    public SaveResultBuilder withId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public SaveResultBuilder withErrors(List<Database.Error> errors) {
+      this.errors = errors;
+      return this;
+    }
+
+    public Database.SaveResult build() {
+      String jsonString = '{"success":' + String.valueOf(success) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
+      return (Database.SaveResult) JSON.deserialize(jsonString, Database.SaveResult.class);
+    }
+  }
+}

--- a/apex-repository/src/classes/DatabaseTestUtils.cls-meta.xml
+++ b/apex-repository/src/classes/DatabaseTestUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/apex-repository/src/classes/InMemoryRepositoryService.cls
+++ b/apex-repository/src/classes/InMemoryRepositoryService.cls
@@ -131,6 +131,7 @@ public class InMemoryRepositoryService implements RepositoryService {
     return new List<SObject>();
   }
 
+  Pattern SOSL_SOBJECT_PATTERN = Pattern.compile('FROM\\s*(\\w+)\\s');
   public List<List<SObject>> find(String sosl) {
     this.findCallParameters.add(sosl);
 

--- a/apex-repository/src/classes/InMemoryRepositoryService.cls
+++ b/apex-repository/src/classes/InMemoryRepositoryService.cls
@@ -144,4 +144,18 @@ public class InMemoryRepositoryService implements RepositoryService {
 
     return result;
   }
+
+  public List<SObject> query(final List<SObject> soql) {
+    SObjectType objectType = soql.getSObjectType();
+    return this.mockDatabase.get(objectType);
+  }
+
+  public List<List<SObject>> find(final List<List<SObject>> sosl) {
+    List<List<SObject>> result = new List<List<SObject>>();
+    for (List<SObject> subResult : sosl) {
+      SObjectType objectType = subResult.getSObjectType();
+      result.add(this.mockDatabase.get(objectType));
+    }
+    return result;
+  }
 }

--- a/apex-repository/src/classes/InMemoryRepositoryService.cls
+++ b/apex-repository/src/classes/InMemoryRepositoryService.cls
@@ -25,14 +25,14 @@ public class InMemoryRepositoryService implements RepositoryService {
     List<Database.SaveResult> results = new List<Database.SaveResult>();
     for (SObject record : records) {
       SObjectType objectType = record.getSObjectType();
-      record.Id = getFakeId(objectType);
+      record.Id = DatabaseTestUtils.getFakeId(objectType);
 
       if (!this.mockDatabase.containsKey(objectType)) {
         this.mockDatabase.put(objectType, new List<SObject>());
       }
       this.mockDatabase.get(objectType).add(record);
 
-      SaveResultBuilder builder = new SaveResultBuilder().withSuccess(true).withId(record.Id);
+      DatabaseTestUtils.SaveResultBuilder builder = new DatabaseTestUtils.SaveResultBuilder().withSuccess(true).withId(record.Id);
 
       results.add(builder.build());
     }
@@ -55,7 +55,7 @@ public class InMemoryRepositoryService implements RepositoryService {
         }
       }
 
-      SaveResultBuilder builder = new SaveResultBuilder().withSuccess(updated).withId(record.Id);
+      DatabaseTestUtils.SaveResultBuilder builder = new DatabaseTestUtils.SaveResultBuilder().withSuccess(updated).withId(record.Id);
 
       results.add(builder.build());
     }
@@ -78,14 +78,14 @@ public class InMemoryRepositoryService implements RepositoryService {
         }
       }
       if (created) {
-        record.Id = getFakeId(objectType);
+        record.Id = DatabaseTestUtils.getFakeId(objectType);
         if (!this.mockDatabase.containsKey(objectType)) {
           this.mockDatabase.put(objectType, new List<SObject>());
         }
         this.mockDatabase.get(objectType).add(record);
       }
 
-      UpsertResultBuilder builder = new UpsertResultBuilder().withSuccess(true).withCreated(created).withId(record.Id);
+      DatabaseTestUtils.UpsertResultBuilder builder = new DatabaseTestUtils.UpsertResultBuilder().withSuccess(true).withCreated(created).withId(record.Id);
 
       results.add(builder.build());
     }
@@ -108,7 +108,7 @@ public class InMemoryRepositoryService implements RepositoryService {
         }
       }
 
-      DeleteResultBuilder builder = new DeleteResultBuilder().withSuccess(deleted).withId(record.Id);
+      DatabaseTestUtils.DeleteResultBuilder builder = new DatabaseTestUtils.DeleteResultBuilder().withSuccess(deleted).withId(record.Id);
 
       results.add(builder.build());
     }
@@ -143,111 +143,5 @@ public class InMemoryRepositoryService implements RepositoryService {
     }
 
     return result;
-  }
-
-  public class DeleteResultBuilder {
-    private Boolean success;
-    private String id;
-    private List<Database.Error> errors;
-
-    public DeleteResultBuilder() {
-      this.success = true;
-      this.errors = new List<Database.Error>();
-    }
-
-    public DeleteResultBuilder withSuccess(Boolean success) {
-      this.success = success;
-      return this;
-    }
-
-    public DeleteResultBuilder withId(String id) {
-      this.id = id;
-      return this;
-    }
-
-    public DeleteResultBuilder withErrors(List<Database.Error> errors) {
-      this.errors = errors;
-      return this;
-    }
-
-    public Database.DeleteResult build() {
-      String jsonString = '{"success":' + String.valueOf(success) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
-      return (Database.DeleteResult) JSON.deserialize(jsonString, Database.DeleteResult.class);
-    }
-  }
-
-  public class UpsertResultBuilder {
-    private Boolean success;
-    private Boolean created;
-    private String id;
-    private List<Database.Error> errors;
-
-    public UpsertResultBuilder() {
-      this.success = true;
-      this.created = false;
-      this.errors = new List<Database.Error>();
-    }
-
-    public UpsertResultBuilder withSuccess(Boolean success) {
-      this.success = success;
-      return this;
-    }
-
-    public UpsertResultBuilder withCreated(Boolean created) {
-      this.created = created;
-      return this;
-    }
-
-    public UpsertResultBuilder withId(String id) {
-      this.id = id;
-      return this;
-    }
-
-    public UpsertResultBuilder withErrors(List<Database.Error> errors) {
-      this.errors = errors;
-      return this;
-    }
-
-    public Database.UpsertResult build() {
-      String jsonString = '{"success":' + String.valueOf(success) + ',"created":' + String.valueOf(created) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
-      return (Database.UpsertResult) JSON.deserialize(jsonString, Database.UpsertResult.class);
-    }
-  }
-
-  public class SaveResultBuilder {
-    private Boolean success;
-    private String id;
-    private List<Database.Error> errors;
-
-    public SaveResultBuilder() {
-      this.success = true;
-      this.errors = new List<Database.Error>();
-    }
-
-    public SaveResultBuilder withSuccess(Boolean success) {
-      this.success = success;
-      return this;
-    }
-
-    public SaveResultBuilder withId(String id) {
-      this.id = id;
-      return this;
-    }
-
-    public SaveResultBuilder withErrors(List<Database.Error> errors) {
-      this.errors = errors;
-      return this;
-    }
-
-    public Database.SaveResult build() {
-      String jsonString = '{"success":' + String.valueOf(success) + ',"id":"' + id + '","errors":' + JSON.serialize(errors) + '}';
-      return (Database.SaveResult) JSON.deserialize(jsonString, Database.SaveResult.class);
-    }
-  }
-
-  static Integer identifier = 1;
-  public static String getFakeId(Schema.SObjectType sot) {
-    String result = String.valueOf(identifier++);
-    return sot.getDescribe().getKeyPrefix() + '0'.repeat(12 - result.length()) + result;
   }
 }

--- a/apex-repository/src/classes/RepositoryFactory.cls
+++ b/apex-repository/src/classes/RepositoryFactory.cls
@@ -81,8 +81,16 @@ public inherited sharing virtual class RepositoryFactory {
       return Database.queryWithBinds(soql, bindMap, this.mode);
     }
 
+    public virtual List<SObject> query(final List<SObject> soql) {
+      return soql;
+    }
+
     public virtual List<List<SObject>> find(final String sosl) {
       return Search.query(sosl, this.mode);
+    }
+
+    public virtual List<List<SObject>> find(final List<List<SObject>> sosl) {
+      return sosl;
     }
   }
 }

--- a/apex-repository/src/classes/RepositoryService.cls
+++ b/apex-repository/src/classes/RepositoryService.cls
@@ -4,5 +4,7 @@ public interface RepositoryService {
   List<Database.UpsertResult> upsertRecords(List<SObject> records, Schema.SObjectField externalIDField, Boolean allOrNone);
   List<Database.DeleteResult> deleteRecords(List<SObject> records, Boolean allOrNone);
   List<SObject> query(String soql, Map<String, Object> bindMap);
+  List<SObject> query(List<SObject> soql);
   List<List<SObject>> find(String sosl);
+  List<List<SObject>> find(List<List<SObject>> sosl);
 }

--- a/apex-repository/test/functional/classes/AsSystemWithSharingFunctionalTest.cls
+++ b/apex-repository/test/functional/classes/AsSystemWithSharingFunctionalTest.cls
@@ -150,7 +150,7 @@ private class AsSystemWithSharingFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+  static void whenRecordIsAccessible_queryString_thenRecordIsReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -170,7 +170,7 @@ private class AsSystemWithSharingFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsNotAccessible_query_thenRecordIsNotReturned() {
+  static void whenRecordIsNotAccessible_queryString_thenRecordIsNotReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -190,7 +190,7 @@ private class AsSystemWithSharingFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsAccessible_find_thenRecordIsReturned() {
+  static void whenRecordIsAccessible_findString_thenRecordIsReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -211,7 +211,7 @@ private class AsSystemWithSharingFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsNotAccessible_find_thenRecordIsNotReturned() {
+  static void whenRecordIsNotAccessible_findString_thenRecordIsNotReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -224,6 +224,87 @@ private class AsSystemWithSharingFunctionalTest {
     System.runAs(dataFactory.getMinimalAccessUser()) {
       // Act
       final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+
+      // Assert
+      Assert.areEqual(0, results[0].size(), 'No record expected but: ' + results);
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      insert testSubject;
+
+      // Act
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
+
+      // Assert
+      Assert.areEqual(1, results.size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_query_thenRecordIsNotReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      // Act
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
+
+      // Assert
+      Assert.areEqual(0, results.size(), 'No record expected but: ' + results);
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_find_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      insert testSubject;
+      Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
+
+      // Act
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
+
+      // Assert
+      Assert.areEqual(1, results[0].size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0][0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_find_thenRecordIsNotReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      // Act
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
 
       // Assert
       Assert.areEqual(0, results[0].size(), 'No record expected but: ' + results);

--- a/apex-repository/test/functional/classes/AsSystemWithoutSharingFunctionalTest.cls
+++ b/apex-repository/test/functional/classes/AsSystemWithoutSharingFunctionalTest.cls
@@ -150,7 +150,7 @@ private class AsSystemWithoutSharingFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+  static void whenRecordIsAccessible_queryString_thenRecordIsReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -162,6 +162,89 @@ private class AsSystemWithoutSharingFunctionalTest {
 
       // Act
       final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+
+      // Assert
+      Assert.areEqual(1, results.size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_queryString_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithoutSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      // Act
+      final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+
+      // Assert
+      Assert.areEqual(0, results.size(), 'No record expected but: ' + results);
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_findString_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithoutSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      insert testSubject;
+      Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
+
+      // Act
+      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+
+      // Assert
+      Assert.areEqual(1, results[0].size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0][0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_findString_thenRecordIsNotReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithoutSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
+
+      // Act
+      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+
+      // Assert
+      Assert.areEqual(0, results[0].size(), 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asSystemWithoutSharing();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUser()) {
+      insert testSubject;
+
+      // Act
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
 
       // Assert
       Assert.areEqual(1, results.size(), 'Expected record not returned.');
@@ -182,7 +265,7 @@ private class AsSystemWithoutSharingFunctionalTest {
 
     System.runAs(dataFactory.getMinimalAccessUser()) {
       // Act
-      final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
 
       // Assert
       Assert.areEqual(0, results.size(), 'No record expected but: ' + results);
@@ -202,7 +285,7 @@ private class AsSystemWithoutSharingFunctionalTest {
       Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
 
       // Act
-      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
 
       // Assert
       Assert.areEqual(1, results[0].size(), 'Expected record not returned.');
@@ -225,7 +308,7 @@ private class AsSystemWithoutSharingFunctionalTest {
       Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
 
       // Act
-      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
 
       // Assert
       Assert.areEqual(0, results[0].size(), 'Expected record not returned.');

--- a/apex-repository/test/functional/classes/AsUserFunctionalTest.cls
+++ b/apex-repository/test/functional/classes/AsUserFunctionalTest.cls
@@ -150,7 +150,7 @@ private class AsUserFunctionalTest {
   }
 
   @isTest
-  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+  static void whenRecordIsAccessible_queryString_thenRecordIsReturned() {
     // Arrange
     final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
     final RepositoryFactory repoFactory = new RepositoryFactory();
@@ -162,6 +162,89 @@ private class AsUserFunctionalTest {
 
       // Act
       final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+
+      // Assert
+      Assert.areEqual(1, results.size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_queryString_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asUser();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUserWithObjectPermissions()) {
+      // Act
+      final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+
+      // Assert
+      Assert.areEqual(0, results.size(), 'No record expected but: ' + results);
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_findString_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asUser();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUserWithObjectPermissions()) {
+      insert testSubject;
+      Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
+
+      // Act
+      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+
+      // Assert
+      Assert.areEqual(1, results[0].size(), 'Expected record not returned.');
+      Assert.areEqual(testSubject.Id, results[0][0].Id, 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsNotAccessible_findString_thenRecordIsNotReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asUser();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+    System.runAs(dataFactory.getAdminUser()) {
+      insert testSubject;
+    }
+
+    System.runAs(dataFactory.getMinimalAccessUserWithObjectPermissions()) {
+      Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
+
+      // Act
+      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+
+      // Assert
+      Assert.areEqual(0, results[0].size(), 'Expected record not returned.');
+    }
+  }
+
+  @isTest
+  static void whenRecordIsAccessible_query_thenRecordIsReturned() {
+    // Arrange
+    final FunctionalDataFactory dataFactory = new FunctionalDataFactory();
+    final RepositoryFactory repoFactory = new RepositoryFactory();
+    final RepositoryService sut = repoFactory.asUser();
+    RepositoryTestSubject__c testSubject = dataFactory.buildTestSubject();
+
+    System.runAs(dataFactory.getMinimalAccessUserWithObjectPermissions()) {
+      insert testSubject;
+
+      // Act
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
 
       // Assert
       Assert.areEqual(1, results.size(), 'Expected record not returned.');
@@ -182,7 +265,7 @@ private class AsUserFunctionalTest {
 
     System.runAs(dataFactory.getMinimalAccessUserWithObjectPermissions()) {
       // Act
-      final List<SObject> results = sut.query('SELECT Id FROM RepositoryTestSubject__c', new Map<String, Object>());
+      final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
 
       // Assert
       Assert.areEqual(0, results.size(), 'No record expected but: ' + results);
@@ -202,7 +285,7 @@ private class AsUserFunctionalTest {
       Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
 
       // Act
-      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
 
       // Assert
       Assert.areEqual(1, results[0].size(), 'Expected record not returned.');
@@ -225,7 +308,7 @@ private class AsUserFunctionalTest {
       Test.setFixedSearchResults(new List<Id>{ testSubject.Id });
 
       // Act
-      final List<List<SObject>> results = sut.find('FIND \'Test*\' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = \'TestSubject\' LIMIT 1)');
+      final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
 
       // Assert
       Assert.areEqual(0, results[0].size(), 'Expected record not returned.');

--- a/apex-repository/test/unit/classes/RepositoryServiceTest.cls
+++ b/apex-repository/test/unit/classes/RepositoryServiceTest.cls
@@ -271,7 +271,7 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithSharingAsSystem_whenQuery_thenReturnResults() {
+  static void givenRepositoryWithSharingAsSystem_whenQueryString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asSystemWithSharing();
@@ -292,7 +292,7 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithoutSharingAsSystem_whenQuery_thenReturnResults() {
+  static void givenRepositoryWithoutSharingAsSystem_whenQueryString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asSystemWithoutSharing();
@@ -313,7 +313,7 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithSharingAsUser_whenQuery_thenReturnResults() {
+  static void givenRepositoryWithSharingAsUser_whenQueryString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asUser();
@@ -334,7 +334,61 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithSharingAsSystem_whenFind_thenReturnResults() {
+  static void givenRepositoryWithSharingAsSystem_whenQuery_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asSystemWithSharing();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    // Act
+    List<SObject> results = sut.query([SELECT Id, Name FROM Account WHERE Name = :acc.Name]);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithoutSharingAsSystem_whenQuery_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asSystemWithoutSharing();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    // Act
+    List<SObject> results = sut.query([SELECT Id, Name FROM Account WHERE Name = :acc.Name]);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithSharingAsUser_whenQuery_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asUser();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    // Act
+    List<SObject> results = sut.query([SELECT Id, Name FROM Account WHERE Name = :acc.Name]);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithSharingAsSystem_whenFindString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asSystemWithSharing();
@@ -355,7 +409,7 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithoutSharingAsSystem_whenFind_thenReturnResults() {
+  static void givenRepositoryWithoutSharingAsSystem_whenFindString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asSystemWithoutSharing();
@@ -376,7 +430,7 @@ private class RepositoryServiceTest {
   }
 
   @IsTest
-  static void givenRepositoryWithSharingAsUser_whenFind_thenReturnResults() {
+  static void givenRepositoryWithSharingAsUser_whenFindString_thenReturnResults() {
     // Arrange
     RepositoryFactory repoFactory = new RepositoryFactory();
     RepositoryService sut = repoFactory.asUser();
@@ -389,6 +443,66 @@ private class RepositoryServiceTest {
 
     // Act
     List<List<SObject>> results = sut.find(sosl);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0][0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithSharingAsSystem_whenFind_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asSystemWithSharing();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    Test.setFixedSearchResults(new List<Id>{ acc.Id });
+
+    // Act
+    List<List<SObject>> results = sut.find([FIND 'Test Account' IN NAME FIELDS RETURNING Account(Id, Name)]);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0][0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithoutSharingAsSystem_whenFind_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asSystemWithoutSharing();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    Test.setFixedSearchResults(new List<Id>{ acc.Id });
+
+    // Act
+    List<List<SObject>> results = sut.find([FIND 'Test Account' IN NAME FIELDS RETURNING Account(Id, Name)]);
+
+    // Assert
+    Assert.areEqual(1, results.size(), 'Expected one record from the query');
+    Account resultAcc = (Account) results[0][0];
+    Assert.areEqual(acc.Name, resultAcc.Name, 'Expected queried record to match');
+  }
+
+  @IsTest
+  static void givenRepositoryWithSharingAsUser_whenFind_thenReturnResults() {
+    // Arrange
+    RepositoryFactory repoFactory = new RepositoryFactory();
+    RepositoryService sut = repoFactory.asUser();
+
+    Account acc = new Account(Name = 'Test Account');
+    insert acc;
+
+    Test.setFixedSearchResults(new List<Id>{ acc.Id });
+
+    // Act
+    List<List<SObject>> results = sut.find([FIND 'Test Account' IN NAME FIELDS RETURNING Account(Id, Name)]);
 
     // Assert
     Assert.areEqual(1, results.size(), 'Expected one record from the query');


### PR DESCRIPTION
Add two methods to deal with static SOQL and SOSL
```java
List<SObject> query(List<SObject> soql);
List<List<SObject>> find(List<List<SObject>> sosl);
```

It allows to write query this way :
```java
final List<SObject> results = sut.query([SELECT Id FROM RepositoryTestSubject__c]);
final List<List<SObject>> results = sut.find([FIND 'Test*' IN NAME FIELDS RETURNING RepositoryTestSubject__c(Id, Name WHERE Name = 'TestSubject' LIMIT 1)]);
```

And so it is easy to rewrite an entire code base using static SOQL/SOSL and directly have the capacity to: 
➖ Mock the behavior in the unit test (technically the code will still be integrated but the test will not care about the integration. It will be slightly slower than a fully decoupled implementation but it will be easier to refactor)
➕ Still have governor limit count in unit test

Here is how you can write mock using [apex mockery](https://github.com/salesforce/apex-mockery) :
```java
private class QueryMockTest {
  @isTest
  static void showMockQuery() {
    // Arrange
    Mock repositoryMock = Mock.forType(RepositoryService.class);
    ServiceForTestPurpose sut = new ServiceForTestPurpose((RepositoryService) queryMock.stub);

    // Mock Configuration part
    MethodSpy querySpy = repositoryMock.spyOn('query');
    
    final List<Account> expectedAccounts = new List<Account>{ new Account(Name = 'Test') };
    querySpy.whenCalledWith(Argument.ofType(List<Account>.class)).thenReturn(expectedAccounts);

    final List<Opportunity> expectedOpportunities = new List<Opportunity>{ new Opportunity(Name = 'Test') };
    querySpy.whenCalledWith(Argument.ofType(List<Opportunity>.class)).thenReturn(expectedOpportunities);

    // Act
    final List<Account> actualAccounts = sut.accounts();
    final List<Opportunity> actualOpportunities = sut.opportunities();

    // Assert
    Assert.areEqual(expectedAccounts, actualAccounts, 'Expected and actual should be equals');
    Assert.areEqual(expectedOpportunities, actualOpportunities, 'Expected and actual should be equals');
    Expect.that(querySpy).hasBeenCalledWith(Argument.ofType(List<Account>.class));
    Expect.that(querySpy).hasBeenCalledWith(Argument.ofType(List<Opportunity>.class));
  }

  public class ServiceForTestPurpose {
    private RepositoryService repository;

    public BU(RepositoryService repository) {
      this.repository = repository;
    }

    public List<Account> accounts() {
      return this.repository.soql([SELECT Id, Name FROM Account]);
    }

    public List<Opportunity> opportunities() {
      return this.repository.soql([SELECT Id, Name FROM Opportunity]);
    }
  }
}
```