### PR TITLE
fix(dal): prevent non-partial DML behaving as partial & add mockId-based mocking

### DIFF
--- a/dal/classes/src/DAL.cls
+++ b/dal/classes/src/DAL.cls
@@ -42,6 +42,91 @@ public inherited sharing class DAL { // RepositoryService ACL
     return dmlMock;
   }
 
+  // Query/Find Mocking by mockId (similar to SOQL.mockId)
+  private static Map<String, QueryMock> queryIdToMock = new Map<String, QueryMock>();
+
+  @TestVisible
+  private static QueryMockable mockQuery(String mockId) {
+    final QueryMock queryMock = new QueryMock();
+    DAL.queryIdToMock.put(mockId, queryMock);
+    return queryMock;
+  }
+
+  @TestVisible
+  private interface QueryMockable {
+    QueryMockable thenReturn(List<SObject> records);
+    QueryMockable thenReturn(Integer count);
+    QueryMockable thenReturnAggregateProxy(List<AggregateResultProxy> aggregateResultProxies);
+    QueryMockable thenReturnSearch(List<List<SObject>> searchResults);
+    void throwException();
+    void throwException(String message);
+  }
+
+  @TestVisible
+  private class QueryMock implements QueryMockable {
+    private List<SObject> mockedRecords;
+    private Integer mockedCount;
+    private List<AggregateResultProxy> mockedAggregateProxies;
+    private List<List<SObject>> mockedSearchResults;
+    private QueryException mockException;
+
+    public QueryMockable thenReturn(List<SObject> records) {
+      this.mockedRecords = records;
+      return this;
+    }
+
+    public QueryMockable thenReturn(Integer count) {
+      this.mockedCount = count;
+      return this;
+    }
+
+    public QueryMockable thenReturnAggregateProxy(List<AggregateResultProxy> aggregateResultProxies) {
+      this.mockedAggregateProxies = aggregateResultProxies;
+      return this;
+    }
+
+    public QueryMockable thenReturnSearch(List<List<SObject>> searchResults) {
+      this.mockedSearchResults = searchResults;
+      return this;
+    }
+
+    public void throwException() {
+      this.throwException('Query mock exception');
+    }
+
+    public void throwException(String message) {
+      this.mockException = new QueryException(message);
+    }
+
+    public List<SObject> getRecords() {
+      if (this.mockException != null) {
+        throw this.mockException;
+      }
+      return this.mockedRecords != null ? this.mockedRecords : new List<SObject>();
+    }
+
+    public Integer getCount() {
+      if (this.mockException != null) {
+        throw this.mockException;
+      }
+      return this.mockedCount != null ? this.mockedCount : 0;
+    }
+
+    public List<AggregateResultProxy> getAggregateProxies() {
+      if (this.mockException != null) {
+        throw this.mockException;
+      }
+      return this.mockedAggregateProxies != null ? this.mockedAggregateProxies : new List<AggregateResultProxy>();
+    }
+
+    public List<List<SObject>> getSearchResults() {
+      if (this.mockException != null) {
+        throw this.mockException;
+      }
+      return this.mockedSearchResults != null ? this.mockedSearchResults : new List<List<SObject>>();
+    }
+  }
+
   @TestVisible
   private interface DmlMockable {
     void throwException();
@@ -466,6 +551,60 @@ public inherited sharing class DAL { // RepositoryService ACL
       return null;
     }
     return DAL.instance.undeleteRecordsPartially(records, accessLevel);
+  }
+
+  // Query/Find methods with mockId support (similar to SOQL.mockId)
+  // Query with mockId
+  public static List<SObject> query(final String soql, final Map<String, Object> bindMap, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getRecords();
+    }
+    return DAL.instance.query(soql, bindMap);
+  }
+  public static List<SObject> query(final String soql, final Map<String, Object> bindMap, AccessLevel accessLevel, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getRecords();
+    }
+    return DAL.instance.query(soql, bindMap, accessLevel);
+  }
+  public static List<SObject> query(final List<SObject> soql, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getRecords();
+    }
+    return DAL.instance.query(soql);
+  }
+  // QueryAggregate with mockId
+  public static List<AggregateResultProxy> queryAggregate(final List<AggregateResult> aggregateResults, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getAggregateProxies();
+    }
+    return DAL.instance.queryAggregate(aggregateResults);
+  }
+  // QueryCount with mockId
+  public static Integer queryCount(final Integer count, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getCount();
+    }
+    return DAL.instance.queryCount(count);
+  }
+  // Find with mockId
+  public static List<List<SObject>> find(final String sosl, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getSearchResults();
+    }
+    return DAL.instance.find(sosl);
+  }
+  public static List<List<SObject>> find(final String sosl, AccessLevel accessLevel, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getSearchResults();
+    }
+    return DAL.instance.find(sosl, accessLevel);
+  }
+  public static List<List<SObject>> find(final List<List<SObject>> sosl, final String mockId) {
+    if (DAL.queryIdToMock.containsKey(mockId)) {
+      return DAL.queryIdToMock.get(mockId).getSearchResults();
+    }
+    return DAL.instance.find(sosl);
   }
 
   private inherited sharing class DALImpl implements IDAL {

--- a/dal/classes/src/DAL.cls
+++ b/dal/classes/src/DAL.cls
@@ -219,12 +219,20 @@ public inherited sharing class DAL { // RepositoryService ACL
   }
 
   private inherited sharing class DALImpl implements IDAL {
+    // Note: here, no Database.DmlOptions is given, so it creates a new instance of it, but the attributes there gets null value, so it behaves as a partial DML since OptAllOrNone is null, as if it was false.
+    // The following alternatives are also valid to enforce allOrNone behavior:
+    //   return Database.insert(records, true);                  // explicit allOrNone = true
+    //   final Database.DmlOptions options = new Database.DmlOptions();
+    //   options.OptAllOrNone = true;
+    //   return Database.insert(records, options);               // explicit DmlOptions with OptAllOrNone = true
+    // But the simplest form already defaults to allOrNone = true
     public List<Database.SaveResult> insertRecords(final List<SObject> records) {
-      return Database.insert(records, new Database.DmlOptions());
+      return Database.insert(records);
     }
 
     public List<Database.SaveResult> insertRecordsPartially(final List<SObject> records) {
       final Database.DmlOptions options = new Database.DmlOptions();
+      // Note: this is not needed, since leaving it as null would behave as false, but for clarity of the intention of the method, it's being set explicitly
       options.OptAllOrNone = false;
       return Database.insert(records, options);
     }
@@ -233,12 +241,14 @@ public inherited sharing class DAL { // RepositoryService ACL
       return Database.insert(records, options);
     }
 
+    // Note: here, no Database.DmlOptions is given, so it creates a new instance of it, but the attributes there gets null value, so it behaves as a partial DML since OptAllOrNone is null, as if it was false.
     public List<Database.SaveResult> insertRecords(final List<SObject> records, AccessLevel accessLevel) {
-      return Database.insert(records, new Database.DmlOptions(), accessLevel);
+      return Database.insert(records, accessLevel);
     }
 
     public List<Database.SaveResult> insertRecordsPartially(final List<SObject> records, AccessLevel accessLevel) {
       final Database.DmlOptions options = new Database.DmlOptions();
+      // Note: this is not needed, since leaving it as null would behave as false, but for clarity of the intention of the method, it's being set explicitly
       options.OptAllOrNone = false;
       return Database.insert(records, options, accessLevel);
     }
@@ -247,12 +257,14 @@ public inherited sharing class DAL { // RepositoryService ACL
       return Database.insert(records, options, accessLevel);
     }
 
+    // Note: here, no Database.DmlOptions is given, so it creates a new instance of it, but the attributes there gets null value, so it behaves as a partial DML since OptAllOrNone is null, as if it was false.
     public List<Database.SaveResult> updateRecords(final List<SObject> records) {
-      return Database.update(records, new Database.DmlOptions());
+      return Database.update(records);
     }
 
     public List<Database.SaveResult> updateRecordsPartially(final List<SObject> records) {
       final Database.DmlOptions options = new Database.DmlOptions();
+      // Note: this is not needed, since leaving it as null would behave as false, but for clarity of the intention of the method, it's being set explicitly
       options.OptAllOrNone = false;
       return Database.update(records, options);
     }
@@ -261,12 +273,14 @@ public inherited sharing class DAL { // RepositoryService ACL
       return Database.update(records, options);
     }
 
+    // Note: here, no Database.DmlOptions is given, so it creates a new instance of it, but the attributes there gets null value, so it behaves as a partial DML since OptAllOrNone is null, as if it was false.
     public List<Database.SaveResult> updateRecords(final List<SObject> records, AccessLevel accessLevel) {
-      return Database.update(records, new Database.DmlOptions(), accessLevel);
+      return Database.update(records, accessLevel);
     }
 
     public List<Database.SaveResult> updateRecordsPartially(final List<SObject> records, AccessLevel accessLevel) {
       final Database.DmlOptions options = new Database.DmlOptions();
+      // Note: this is not needed, since leaving it as null would behave as false, but for clarity of the intention of the method, it's being set explicitly
       options.OptAllOrNone = false;
       return Database.update(records, options, accessLevel);
     }

--- a/dal/classes/src/DAL.cls
+++ b/dal/classes/src/DAL.cls
@@ -32,6 +32,53 @@ public inherited sharing class DAL { // RepositoryService ACL
     }
   }
 
+  // DML Mocking by mockId (similar to SOQL.mockId)
+  private static Map<String, DmlMock> dmlIdToMock = new Map<String, DmlMock>();
+
+  @TestVisible
+  private static DmlMockable mock(String mockId) {
+    final DmlMock dmlMock = new DmlMock();
+    DAL.dmlIdToMock.put(mockId, dmlMock);
+    return dmlMock;
+  }
+
+  @TestVisible
+  private interface DmlMockable {
+    void throwException();
+    void throwException(String message);
+  }
+
+  @TestVisible
+  private class DmlMock implements DmlMockable {
+    private DmlException mockException;
+
+    public void throwException() {
+      this.throwException('DML mock exception');
+    }
+
+    public void throwException(String message) {
+      this.mockException = new DmlException();
+      this.mockException.setMessage(message);
+    }
+
+    public Boolean hasException() {
+      return this.mockException != null;
+    }
+
+    public void execute(final List<SObject> records, final Boolean assignIds) {
+      if (this.hasException()) {
+        throw this.mockException;
+      }
+      if (assignIds) {
+        for (SObject sob : records) {
+          if (sob.Id == null) {
+            sob.Id = DatabaseTestUtils.getFakeId(sob.getSObjectType());
+          }
+        }
+      }
+    }
+  }
+
   @TestVisible
   private class Stub { // Mocking library ACL
     private final Mock dalMock;
@@ -216,6 +263,209 @@ public inherited sharing class DAL { // RepositoryService ACL
   }
   public static List<List<SObject>> find(final List<List<SObject>> sosl) {
     return DAL.instance.find(soSl);
+  }
+
+  // DML methods with mockId support (similar to SOQL.mockId)
+  // Insert with mockId
+  public static List<Database.SaveResult> insertRecords(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecords(records);
+  }
+  public static List<Database.SaveResult> insertRecordsPartially(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecordsPartially(records);
+  }
+  public static List<Database.SaveResult> insertRecords(final List<SObject> records, final Database.DmlOptions options, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecords(records, options);
+  }
+  public static List<Database.SaveResult> insertRecords(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecords(records, accessLevel);
+  }
+  public static List<Database.SaveResult> insertRecordsPartially(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecordsPartially(records, accessLevel);
+  }
+  public static List<Database.SaveResult> insertRecords(final List<SObject> records, final Database.DmlOptions options, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.insertRecords(records, options, accessLevel);
+  }
+  // Update with mockId
+  public static List<Database.SaveResult> updateRecords(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecords(records);
+  }
+  public static List<Database.SaveResult> updateRecordsPartially(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecordsPartially(records);
+  }
+  public static List<Database.SaveResult> updateRecords(final List<SObject> records, final Database.DmlOptions options, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecords(records, options);
+  }
+  public static List<Database.SaveResult> updateRecords(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecords(records, accessLevel);
+  }
+  public static List<Database.SaveResult> updateRecordsPartially(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecordsPartially(records, accessLevel);
+  }
+  public static List<Database.SaveResult> updateRecords(final List<SObject> records, final Database.DmlOptions options, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.updateRecords(records, options, accessLevel);
+  }
+  // Upsert with mockId
+  public static List<Database.UpsertResult> upsertRecords(final List<SObject> records, final Schema.SObjectField externalIDField, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecords(records, externalIDField);
+  }
+  public static List<Database.UpsertResult> upsertRecordsPartially(final List<SObject> records, final Schema.SObjectField externalIDField, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecordsPartially(records, externalIDField);
+  }
+  public static List<Database.UpsertResult> upsertRecords(final List<SObject> records, final Schema.SObjectField externalIDField, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecords(records, externalIDField, accessLevel);
+  }
+  public static List<Database.UpsertResult> upsertRecordsPartially(final List<SObject> records, final Schema.SObjectField externalIDField, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecordsPartially(records, externalIDField, accessLevel);
+  }
+  public static List<Database.UpsertResult> upsertRecords(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecords(records);
+  }
+  public static List<Database.UpsertResult> upsertRecordsPartially(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecordsPartially(records);
+  }
+  public static List<Database.UpsertResult> upsertRecords(final List<SObject> records, final AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecords(records, accessLevel);
+  }
+  public static List<Database.UpsertResult> upsertRecordsPartially(final List<SObject> records, final AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, true);
+      return null;
+    }
+    return DAL.instance.upsertRecordsPartially(records, accessLevel);
+  }
+  // Delete with mockId
+  public static List<Database.DeleteResult> deleteRecords(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.deleteRecords(records);
+  }
+  public static List<Database.DeleteResult> deleteRecordsPartially(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.deleteRecordsPartially(records);
+  }
+  public static List<Database.DeleteResult> deleteRecords(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.deleteRecords(records, accessLevel);
+  }
+  public static List<Database.DeleteResult> deleteRecordsPartially(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.deleteRecordsPartially(records, accessLevel);
+  }
+  // Undelete with mockId
+  public static List<Database.UndeleteResult> undeleteRecords(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.undeleteRecords(records);
+  }
+  public static List<Database.UndeleteResult> undeleteRecordsPartially(final List<SObject> records, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.undeleteRecordsPartially(records);
+  }
+  public static List<Database.UndeleteResult> undeleteRecords(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.undeleteRecords(records, accessLevel);
+  }
+  public static List<Database.UndeleteResult> undeleteRecordsPartially(final List<SObject> records, AccessLevel accessLevel, final String mockId) {
+    if (DAL.dmlIdToMock.containsKey(mockId)) {
+      DAL.dmlIdToMock.get(mockId).execute(records, false);
+      return null;
+    }
+    return DAL.instance.undeleteRecordsPartially(records, accessLevel);
   }
 
   private inherited sharing class DALImpl implements IDAL {

--- a/dal/classes/test/DAL_TEST.cls
+++ b/dal/classes/test/DAL_TEST.cls
@@ -447,4 +447,157 @@ private class DAL_TEST {
     // Assert
     Assert.isNotNull(acc.Id);
   }
+
+  // mockId-based Query/Find mocking tests
+
+  @isTest
+  static void givenMockQuery_whenQueryIsCalled_thenReturnsMockedRecords() {
+    // Arrange
+    List<Account> mockedAccounts = new List<Account>{ new Account(Name = 'Mocked Account') };
+    DAL.mockQuery('queryAccounts').thenReturn(mockedAccounts);
+
+    // Act
+    List<SObject> results = DAL.query('SELECT Id, Name FROM Account', new Map<String, Object>(), 'queryAccounts');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.areEqual('Mocked Account', ((Account) results[0]).Name);
+  }
+
+  @isTest
+  static void givenMockQuery_whenQueryWithAccessLevelIsCalled_thenReturnsMockedRecords() {
+    // Arrange
+    List<Account> mockedAccounts = new List<Account>{ new Account(Name = 'Mocked') };
+    DAL.mockQuery('queryAccessLevel').thenReturn(mockedAccounts);
+
+    // Act
+    List<SObject> results = DAL.query('SELECT Id FROM Account', new Map<String, Object>(), AccessLevel.SYSTEM_MODE, 'queryAccessLevel');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+  }
+
+  @isTest
+  static void givenMockQuery_whenInlineQueryIsCalled_thenReturnsMockedRecords() {
+    // Arrange
+    List<Account> mockedAccounts = new List<Account>{ new Account(Name = 'Inline Mock') };
+    DAL.mockQuery('inlineQuery').thenReturn(mockedAccounts);
+
+    // Act
+    List<SObject> results = DAL.query([SELECT Id FROM Account], 'inlineQuery');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.areEqual('Inline Mock', ((Account) results[0]).Name);
+  }
+
+  @isTest
+  static void givenMockQuery_whenQueryCountIsCalled_thenReturnsMockedCount() {
+    // Arrange
+    DAL.mockQuery('countAccounts').thenReturn(42);
+
+    // Act
+    Integer count = DAL.queryCount([SELECT COUNT() FROM Account], 'countAccounts');
+
+    // Assert
+    Assert.areEqual(42, count);
+  }
+
+  @isTest
+  static void givenMockQuery_whenQueryAggregateIsCalled_thenReturnsMockedAggregateProxies() {
+    // Arrange
+    AggregateResultProxy proxy = new AggregateResultProxy(
+      (AggregateResult) DatabaseTestUtils.makeData(AggregateResult.class, new Map<String, Object>{ 'countId' => 5 })
+    );
+    DAL.mockQuery('aggregateQuery').thenReturnAggregateProxy(new List<AggregateResultProxy>{ proxy });
+
+    // Act
+    List<AggregateResultProxy> results = DAL.queryAggregate([SELECT Count(Id) countId FROM Account], 'aggregateQuery');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.areEqual(5, results[0].get('countId'));
+  }
+
+  @isTest
+  static void givenMockQuery_whenFindIsCalled_thenReturnsMockedSearchResults() {
+    // Arrange
+    List<List<SObject>> mockedResults = new List<List<SObject>>{ new List<Account>{ new Account(Name = 'Found') } };
+    DAL.mockQuery('findAccounts').thenReturnSearch(mockedResults);
+
+    // Act
+    List<List<SObject>> results = DAL.find('FIND \'Test\' IN NAME FIELDS RETURNING Account', 'findAccounts');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.areEqual(1, results[0].size());
+    Assert.areEqual('Found', ((Account) results[0][0]).Name);
+  }
+
+  @isTest
+  static void givenMockQuery_whenFindWithAccessLevelIsCalled_thenReturnsMockedSearchResults() {
+    // Arrange
+    List<List<SObject>> mockedResults = new List<List<SObject>>{ new List<Account>{ new Account(Name = 'Found') } };
+    DAL.mockQuery('findAccessLevel').thenReturnSearch(mockedResults);
+
+    // Act
+    List<List<SObject>> results = DAL.find('FIND \'Test\' IN NAME FIELDS RETURNING Account', AccessLevel.SYSTEM_MODE, 'findAccessLevel');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+  }
+
+  @isTest
+  static void givenMockQuery_whenInlineFindIsCalled_thenReturnsMockedSearchResults() {
+    // Arrange
+    List<List<SObject>> mockedResults = new List<List<SObject>>{ new List<Account>{ new Account(Name = 'InlineFind') } };
+    DAL.mockQuery('inlineFind').thenReturnSearch(mockedResults);
+
+    // Act
+    List<List<SObject>> results = DAL.find([FIND 'Test' IN NAME FIELDS RETURNING Account(Id, Name)], 'inlineFind');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.areEqual('InlineFind', ((Account) results[0][0]).Name);
+  }
+
+  @isTest
+  static void givenMockQuery_whenThrowExceptionConfigured_thenThrowsQueryException() {
+    // Arrange
+    DAL.mockQuery('failingQuery').throwException('Custom query error');
+
+    // Act & Assert
+    try {
+      DAL.query('SELECT Id FROM Account', new Map<String, Object>(), 'failingQuery');
+      Assert.fail('Expected QueryException');
+    } catch (QueryException e) {
+      Assert.isTrue(e.getMessage().contains('Custom query error'));
+    }
+  }
+
+  @isTest
+  static void givenMockQuery_whenNoMockRegistered_thenDelegatesToInstance() {
+    // Act - no mock registered, should execute normally
+    List<SObject> results = DAL.query('SELECT Id FROM Account', new Map<String, Object>(), 'unmockedQuery');
+
+    // Assert
+    Assert.areEqual(0, results.size());
+  }
+
+  @isTest
+  static void givenMultipleMockQueries_whenCalledIndependently_thenEachReturnsDifferentResults() {
+    // Arrange
+    DAL.mockQuery('queryFirst').thenReturn(new List<Account>{ new Account(Name = 'First') });
+    DAL.mockQuery('querySecond').thenReturn(new List<Account>{ new Account(Name = 'Second'), new Account(Name = 'Third') });
+
+    // Act
+    List<SObject> firstResults = DAL.query('SELECT Id FROM Account', new Map<String, Object>(), 'queryFirst');
+    List<SObject> secondResults = DAL.query('SELECT Id FROM Account', new Map<String, Object>(), 'querySecond');
+
+    // Assert
+    Assert.areEqual(1, firstResults.size());
+    Assert.areEqual('First', ((Account) firstResults[0]).Name);
+    Assert.areEqual(2, secondResults.size());
+    Assert.areEqual('Second', ((Account) secondResults[0]).Name);
+  }
 }

--- a/dal/classes/test/DAL_TEST.cls
+++ b/dal/classes/test/DAL_TEST.cls
@@ -138,6 +138,11 @@ private class DAL_TEST {
     DAL.find([FIND 'Test' IN NAME FIELDS RETURNING Account(Id, Name)]);
     Expect.that(findSpy).hasBeenCalledWith(Argument.ofType(List<List<Account>>.class));
 
+    // WARNING: These dynamic SOSL strings use escaped single quotes ('\''). If executed against the
+    // real org (not mocked), DAL.find() would call String.escapeSingleQuotes() on top of them,
+    // producing double-escaped backslashes and failing with: "no viable alternative at character '\'".
+    // They only pass here because the DAL is stubbed and the SOSL is never actually executed.
+    // If unmocked, the correct syntax would be: 'FIND {Test} IN NAME FIELDS RETURNING Account (Id, Name)'
     DAL.find('FIND \'Test\' IN NAME FIELDS RETURNING Account (Id, Name)');
     Expect.that(findSpy).hasBeenCalledWith(Argument.ofType(String.class));
 
@@ -160,18 +165,33 @@ private class DAL_TEST {
     Expect.that(insertSpy).hasNotBeenCalled();
   }
 
+  // FIX: This test was failing for two reasons:
+  // 1) The original code reused the same Account instance across all insert calls. After the first
+  //    successful insert, Salesforce assigns an Id to the record in-memory. Subsequent inserts of
+  //    the same instance then fail with: 'cannot specify Id in an insert call'.
+  // 2) Before the allOrNone bugfix, the non-partial insert methods were silently swallowing
+  //    this error because Database.DmlOptions().OptAllOrNone defaults to null (false), so
+  //    they behaved as partial inserts — returning a failed SaveResult instead of throwing.
+  //    The test only asserted results.size() == 1, which passed regardless of success/failure.
+  // Solution: use a separate Account instance for each insert call.
   @isTest
   static void givenDAL_whenInsertRecordsIsCalled_thenItTriesToInsertRecords() {
-    // Arrange
-    Account acc = new Account(Name = 'Test');
+    // Arrange - each call needs its own Account; after the first insert, the record gets an Id
+    // and a second insert would fail with 'cannot specify Id in an insert call'
+    Account acc1 = new Account(Name = 'Test1');
+    Account acc2 = new Account(Name = 'Test2');
+    Account acc3 = new Account(Name = 'Test3');
+    Account acc4 = new Account(Name = 'Test4');
+    Account acc5 = new Account(Name = 'Test5');
+    Account acc6 = new Account(Name = 'Test6');
 
     // Act
-    List<Database.SaveResult> results = DAL.insertRecords(new List<Account>{ acc });
-    List<Database.SaveResult> resultsOptions = DAL.insertRecords(new List<Account>{ acc }, new Database.DMLOptions());
-    List<Database.SaveResult> resultsPartially = DAL.insertRecordsPartially(new List<Account>{ acc });
-    List<Database.SaveResult> resultsWithMode = DAL.insertRecords(new List<Account>{ acc }, AccessLevel.SYSTEM_MODE);
-    List<Database.SaveResult> resultsOptionsWithMode = DAL.insertRecords(new List<Account>{ acc }, new Database.DMLOptions(), AccessLevel.SYSTEM_MODE);
-    List<Database.SaveResult> resultsPartiallyWithMode = DAL.insertRecordsPartially(new List<Account>{ acc }, AccessLevel.SYSTEM_MODE);
+    List<Database.SaveResult> results = DAL.insertRecords(new List<Account>{ acc1 });
+    List<Database.SaveResult> resultsOptions = DAL.insertRecords(new List<Account>{ acc2 }, new Database.DMLOptions());
+    List<Database.SaveResult> resultsPartially = DAL.insertRecordsPartially(new List<Account>{ acc3 });
+    List<Database.SaveResult> resultsWithMode = DAL.insertRecords(new List<Account>{ acc4 }, AccessLevel.SYSTEM_MODE);
+    List<Database.SaveResult> resultsOptionsWithMode = DAL.insertRecords(new List<Account>{ acc5 }, new Database.DMLOptions(), AccessLevel.SYSTEM_MODE);
+    List<Database.SaveResult> resultsPartiallyWithMode = DAL.insertRecordsPartially(new List<Account>{ acc6 }, AccessLevel.SYSTEM_MODE);
 
     // Assert
     Assert.areEqual(1, results.size());
@@ -182,10 +202,19 @@ private class DAL_TEST {
     Assert.areEqual(1, resultsPartiallyWithMode.size());
   }
 
+  // FIX: This test was failing because the original code created an Account without inserting it,
+  // so it had no Id. Calling Database.update on a record without an Id throws:
+  // 'MISSING_ARGUMENT, Id not specified in an update call'. Before the allOrNone bugfix, this
+  // error was silently swallowed (same partial-insert issue as above), and the test passed
+  // because it only checked results.size() == 1.
+  // Solution: insert the Account first so it gets a valid Id before updating.
   @isTest
   static void givenDAL_whenUpdateRecordsIsCalled_thenItTriesToUpdateRecords() {
-    // Arrange
+    // Arrange - insert first so the record has a valid Id for update
     Account acc = new Account(Name = 'Test');
+    insert acc;
+
+    acc.Name = 'Updated';
 
     // Act
     List<Database.SaveResult> results = DAL.updateRecords(new List<Account>{ acc });
@@ -297,17 +326,83 @@ private class DAL_TEST {
     Assert.areEqual(0, count);
   }
 
+  // FIX: This test was failing because the original dynamic SOSL strings used escaped single quotes:
+  //   'FIND \'Test\' IN NAME FIELDS RETURNING Account (Id, Name)'
+  // The DAL.find() implementation calls String.escapeSingleQuotes() on the input, which added
+  // extra backslashes to the already-escaped quotes, producing invalid SOSL:
+  //   FIND \\'Test\\' ... → "no viable alternative at character '\'"
+  // Solution: use SOSL curly-brace syntax {Test} instead of single-quoted 'Test' for dynamic strings.
+  // The inline SOSL (first call) was already fine since it's compiled, not string-escaped.
   @isTest
   static void givenDAL_whenFindIsCalled_thenItTriesToFindRecords() {
     // Act
     List<List<SObject>> resultsStatic = DAL.find([FIND 'Test' IN NAME FIELDS RETURNING Account(Id, Name)]);
-    List<List<SObject>> resultsDynamic = DAL.find('FIND \'Test\' IN NAME FIELDS RETURNING Account (Id, Name)');
-    List<List<SObject>> resultsDynamicWithMode = DAL.find('FIND \'Test\' IN NAME FIELDS RETURNING Account (Id, Name)', AccessLevel.SYSTEM_MODE);
+    List<List<SObject>> resultsDynamic = DAL.find('FIND {Test} IN NAME FIELDS RETURNING Account (Id, Name)');
+    List<List<SObject>> resultsDynamicWithMode = DAL.find('FIND {Test} IN NAME FIELDS RETURNING Account (Id, Name)', AccessLevel.SYSTEM_MODE);
 
     // Assert
     Assert.areEqual(0, resultsStatic[0].size());
     Assert.areEqual(0, resultsDynamic[0].size());
     Assert.areEqual(0, resultsDynamicWithMode[0].size());
+  }
+
+  // Regression tests: non-partial DML must throw on failure (allOrNone = true)
+
+  @isTest
+  static void givenNonPartialInsert_whenRecordIsInvalid_thenThrowsDmlException() {
+    // Arrange - Account without required Name field on an org where Name is required
+    // Using a record that will definitely fail: inserting a Contact without LastName
+    Contact invalidContact = new Contact(); // LastName is required
+
+    // Act & Assert
+    try {
+      DAL.insertRecords(new List<Contact>{ invalidContact });
+      Assert.fail('Expected DmlException for non-partial insert of invalid record');
+    } catch (DmlException e) {
+      Assert.isTrue(e.getMessage().contains('REQUIRED_FIELD_MISSING') || e.getMessage().contains('LastName'));
+    }
+  }
+
+  @isTest
+  static void givenPartialInsert_whenRecordIsInvalid_thenDoesNotThrow() {
+    // Arrange
+    Contact invalidContact = new Contact(); // LastName is required
+
+    // Act - partial insert should NOT throw
+    List<Database.SaveResult> results = DAL.insertRecordsPartially(new List<Contact>{ invalidContact });
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.isFalse(results[0].isSuccess(), 'Partial insert should return failure result, not throw');
+  }
+
+  @isTest
+  static void givenNonPartialUpdate_whenRecordIsInvalid_thenThrowsDmlException() {
+    // Arrange - Update a record with a fake Id that doesn't exist
+    Account acc = new Account(Name = 'Test');
+    acc.Id = DatabaseTestUtils.getFakeId(Account.SObjectType);
+
+    // Act & Assert
+    try {
+      DAL.updateRecords(new List<Account>{ acc });
+      Assert.fail('Expected DmlException for non-partial update of non-existent record');
+    } catch (DmlException e) {
+      Assert.isNotNull(e.getMessage());
+    }
+  }
+
+  @isTest
+  static void givenPartialUpdate_whenRecordIsInvalid_thenDoesNotThrow() {
+    // Arrange
+    Account acc = new Account(Name = 'Test');
+    acc.Id = DatabaseTestUtils.getFakeId(Account.SObjectType);
+
+    // Act - partial update should NOT throw
+    List<Database.SaveResult> results = DAL.updateRecordsPartially(new List<Account>{ acc });
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.isFalse(results[0].isSuccess(), 'Partial update should return failure result, not throw');
   }
 
   // mockId-based DML mocking tests
@@ -503,12 +598,17 @@ private class DAL_TEST {
     Assert.areEqual(42, count);
   }
 
+  // FIX: This test was failing because the original code built the AggregateResultProxy via:
+  //   new AggregateResultProxy((AggregateResult) DatabaseTestUtils.makeData(AggregateResult.class, ...))
+  // DatabaseTestUtils.makeData uses JSON.serialize/deserialize to create the AggregateResult.
+  // However, AggregateResult.getPopulatedFieldsAsMap() (used by the public constructor) does not
+  // return fields populated through deserialization — it returns an empty map, so proxy.get('countId')
+  // returned null instead of 5.
+  // Solution: use the @TestVisible private constructor that accepts a Map<String, Object> directly.
   @isTest
   static void givenMockQuery_whenQueryAggregateIsCalled_thenReturnsMockedAggregateProxies() {
     // Arrange
-    AggregateResultProxy proxy = new AggregateResultProxy(
-      (AggregateResult) DatabaseTestUtils.makeData(AggregateResult.class, new Map<String, Object>{ 'countId' => 5 })
-    );
+    AggregateResultProxy proxy = new AggregateResultProxy(new Map<String, Object>{ 'countId' => 5 });
     DAL.mockQuery('aggregateQuery').thenReturnAggregateProxy(new List<AggregateResultProxy>{ proxy });
 
     // Act
@@ -519,6 +619,10 @@ private class DAL_TEST {
     Assert.areEqual(5, results[0].get('countId'));
   }
 
+  // NOTE: The dynamic SOSL string below uses escaped single quotes ('\''). This only works
+  // because the mockId intercepts the call before DAL.find() reaches String.escapeSingleQuotes().
+  // If no mock were registered, it would fail with: "no viable alternative at character '\'".
+  // The correct unmocked syntax would be: 'FIND {Test} IN NAME FIELDS RETURNING Account'
   @isTest
   static void givenMockQuery_whenFindIsCalled_thenReturnsMockedSearchResults() {
     // Arrange
@@ -534,6 +638,8 @@ private class DAL_TEST {
     Assert.areEqual('Found', ((Account) results[0][0]).Name);
   }
 
+  // NOTE: Same single-quote issue as above — only works because the mockId intercepts the call.
+  // See givenMockQuery_whenFindIsCalled_thenReturnsMockedSearchResults for details.
   @isTest
   static void givenMockQuery_whenFindWithAccessLevelIsCalled_thenReturnsMockedSearchResults() {
     // Arrange

--- a/dal/classes/test/DAL_TEST.cls
+++ b/dal/classes/test/DAL_TEST.cls
@@ -309,4 +309,142 @@ private class DAL_TEST {
     Assert.areEqual(0, resultsDynamic[0].size());
     Assert.areEqual(0, resultsDynamicWithMode[0].size());
   }
+
+  // mockId-based DML mocking tests
+
+  @isTest
+  static void givenMockId_whenInsertRecordsIsCalled_thenMockAssignsFakeIds() {
+    // Arrange
+    DAL.mock('insertAccounts');
+    DAL.mock('insertContacts');
+    Account acc = new Account(Name = 'Test Account');
+    Contact con = new Contact(LastName = 'Test Contact');
+
+    // Act
+    DAL.insertRecords(new List<Account>{ acc }, 'insertAccounts');
+    DAL.insertRecords(new List<Contact>{ con }, 'insertContacts');
+
+    // Assert
+    Assert.isNotNull(acc.Id, 'Account should have a fake Id assigned');
+    Assert.isNotNull(con.Id, 'Contact should have a fake Id assigned');
+    Assert.isTrue(acc.Id != con.Id, 'Each record should get a unique fake Id');
+  }
+
+  @isTest
+  static void givenMockId_whenMultipleInsertsUseDifferentMockIds_thenEachIsMockedIndependently() {
+    // Arrange
+    DAL.mock('insertFirst');
+    DAL.mock('insertSecond').throwException('Second insert failed');
+    Account acc = new Account(Name = 'First');
+    Account acc2 = new Account(Name = 'Second');
+
+    // Act
+    DAL.insertRecords(new List<Account>{ acc }, 'insertFirst');
+
+    // Assert - first insert succeeds
+    Assert.isNotNull(acc.Id);
+
+    // Act & Assert - second insert throws
+    try {
+      DAL.insertRecords(new List<Account>{ acc2 }, 'insertSecond');
+      Assert.fail('Expected DmlException');
+    } catch (DmlException e) {
+      Assert.isTrue(e.getMessage().contains('Second insert failed'));
+    }
+  }
+
+  @isTest
+  static void givenMockId_whenNoMockRegistered_thenDelegatesToInstance() {
+    // Arrange
+    Account acc = new Account(Name = 'Test');
+
+    // Act - no mock registered for 'unmockedInsert', should hit real DB
+    List<Database.SaveResult> results = DAL.insertRecords(new List<Account>{ acc }, 'unmockedInsert');
+
+    // Assert
+    Assert.areEqual(1, results.size());
+    Assert.isTrue(results[0].isSuccess());
+  }
+
+  @isTest
+  static void givenMockId_whenUpdateRecordsIsCalled_thenMockExecutes() {
+    // Arrange
+    DAL.mock('updateAccounts');
+    Account acc = new Account(Name = 'Test');
+    acc.Id = DatabaseTestUtils.getFakeId(Account.SObjectType);
+
+    // Act - should not throw, mock intercepts
+    DAL.updateRecords(new List<Account>{ acc }, 'updateAccounts');
+
+    // Assert - no exception means mock worked (real update of fake Id would fail)
+    Assert.isNotNull(acc.Id);
+  }
+
+  @isTest
+  static void givenMockId_whenDeleteRecordsIsCalled_thenMockExecutes() {
+    // Arrange
+    DAL.mock('deleteAccounts');
+    Account acc = new Account(Name = 'Test');
+    acc.Id = DatabaseTestUtils.getFakeId(Account.SObjectType);
+
+    // Act - should not throw, mock intercepts
+    DAL.deleteRecords(new List<Account>{ acc }, 'deleteAccounts');
+
+    // Assert - no exception means mock worked
+    Assert.isNotNull(acc.Id);
+  }
+
+  @isTest
+  static void givenMockId_whenUndeleteRecordsIsCalled_thenMockExecutes() {
+    // Arrange
+    DAL.mock('undeleteAccounts');
+    Account acc = new Account(Name = 'Test');
+    acc.Id = DatabaseTestUtils.getFakeId(Account.SObjectType);
+
+    // Act - should not throw, mock intercepts
+    DAL.undeleteRecords(new List<Account>{ acc }, 'undeleteAccounts');
+
+    // Assert - no exception means mock worked
+    Assert.isNotNull(acc.Id);
+  }
+
+  @isTest
+  static void givenMockId_whenThrowExceptionWithDefaultMessage_thenThrowsDmlException() {
+    // Arrange
+    DAL.mock('failingInsert').throwException();
+
+    // Act & Assert
+    try {
+      DAL.insertRecords(new List<Account>{ new Account(Name = 'Test') }, 'failingInsert');
+      Assert.fail('Expected DmlException');
+    } catch (DmlException e) {
+      Assert.isTrue(e.getMessage().contains('DML mock exception'));
+    }
+  }
+
+  @isTest
+  static void givenMockId_whenUpsertRecordsIsCalled_thenMockAssignsFakeIds() {
+    // Arrange
+    DAL.mock('upsertAccounts');
+    Account acc = new Account(Name = 'Test');
+
+    // Act
+    DAL.upsertRecords(new List<Account>{ acc }, 'upsertAccounts');
+
+    // Assert
+    Assert.isNotNull(acc.Id, 'Upsert mock should assign fake Id');
+  }
+
+  @isTest
+  static void givenMockId_whenInsertWithAccessLevel_thenMockIntercepts() {
+    // Arrange
+    DAL.mock('insertWithAccess');
+    Account acc = new Account(Name = 'Test');
+
+    // Act
+    DAL.insertRecords(new List<Account>{ acc }, AccessLevel.SYSTEM_MODE, 'insertWithAccess');
+
+    // Assert
+    Assert.isNotNull(acc.Id);
+  }
 }


### PR DESCRIPTION
This PR contains three changes:

1. Fix: Non-partial DML behaving as partial
insertRecords and updateRecords (non-partial) were using new Database.DmlOptions() without setting OptAllOrNone, which defaults to null and behaves as false. This caused them to silently allow partial failures. Fixed by using the simpler Database.insert(records) / Database.update(records) overloads that default to allOrNone = true.

2. Feature: mockId-based DML mocking
Added a mockId parameter to all DML methods, similar to [SOQL's](https://github.com/beyond-the-cloud-dev/soql-lib/blob/main/force-app/main/default/classes/standard-soql/SOQL.cls) mockId pattern. This allows multiple DML calls in the same transaction to be independently mocked in tests.

3. Feature: mockId-based Query/Find mocking
Extended the mockId pattern to query, queryAggregate, queryCount, and find, so read operations can also be independently mocked.

Note: I've added some inline comments to explain the reasoning behind certain decisions (e.g., why OptAllOrNone = false is set explicitly even though it's the default, or the alternative approaches considered for the fix). These are meant to help with understanding, but feel free to remove them if you prefer to keep the code cleaner — no hard feelings at all.